### PR TITLE
3-wnsmir

### DIFF
--- a/wnsmir/DP/2096내려가기.py
+++ b/wnsmir/DP/2096내려가기.py
@@ -1,0 +1,34 @@
+N = int(input())
+matrix = []
+
+for i in range(N):
+    row = list(map(int, input().split()))
+    matrix.append(row)
+
+#이전 줄
+prev_dp_max = matrix[0][:]
+prev_dp_min = matrix[0][:]
+
+# 두번째 줄부터
+for i in range(1, N):
+    curr_dp_max = [0] * 3  #현재줄의 최대값
+    curr_dp_min = [0] * 3  #현재줄의 최소값
+    
+    # 첫번째 열 (j == 0)
+    curr_dp_max[0] = matrix[i][0] + max(prev_dp_max[0], prev_dp_max[1])
+    curr_dp_min[0] = matrix[i][0] + min(prev_dp_min[0], prev_dp_min[1])
+    
+    # 두번째 열 (j == 1)
+    curr_dp_max[1] = matrix[i][1] + max(prev_dp_max[0], prev_dp_max[1], prev_dp_max[2])
+    curr_dp_min[1] = matrix[i][1] + min(prev_dp_min[0], prev_dp_min[1], prev_dp_min[2])
+    
+    # 세번째 열 (j == 2)
+    curr_dp_max[2] = matrix[i][2] + max(prev_dp_max[1], prev_dp_max[2])
+    curr_dp_min[2] = matrix[i][2] + min(prev_dp_min[1], prev_dp_min[2])
+
+    # 현재줄을 이전 줄로 업데이트 => 메모리절약을 위해
+    prev_dp_max = curr_dp_max[:]
+    prev_dp_min = curr_dp_min[:]
+
+# 마지막 줄의 최대값과 최소값 출력
+print(max(prev_dp_max), min(prev_dp_min))


### PR DESCRIPTION
## 🔗 문제 링크
https://www.acmicpc.net/problem/2096

## ✔️ 소요된 시간
50m

## ✨ 수도 코드
1. 첫번쨰 행의 값들을 입력받는다.
2. 두번째줄부터 N까지 반복문 설정
3. 행 하나를 입력받고 그 행의 DP배열을 만들어준다.
4. 
첫번째열은 이전 행에서 첫번째 두번째 열에서만 값을 더할 수 있으므로 [0],[1]만 계산해본 뒤 max, min 값 추출후 현재 dp배열에 입력해준다.

두번째열은 첫번쨰 두번째 세번째열 모두에서 받을 수 있으므로 [0],[1],[2] 에서 모두 더해본 뒤 max, min값을 추출해 currDP배열에 넣어준다. 세번째는 생략

5. 다음행으로 넘어가기전 현재값을 prev값으로 넣어준뒤 반복한다.

문제와 슈도코드만 봤을때 잘 이해가 안갈 수 있을것 같아 예시로 dp배열이 두번 반복하는동안 어떻게 저장되는지 보여드리겠습니다.

dp_max = [
    [1, 2, 3],  # 첫번째 줄
    [6, 8, 9],  # 두번째 줄
    [0, 0, 0]   # 아직 계산되지 않음
]
dp_max = [
    [1, 2, 3],  # 첫번째 줄
    [6, 8, 9],  # 두번째 줄
    [12, 18, 9] # 세번째 줄



## 📚 새롭게 알게된 내용
사실 초기코드는
N = int(input())
matrix = []

for i in range(N):
    row = list(map(int, input().split()))
    matrix.append(row)

#이전 줄
prev_dp_max = matrix[0][:]
prev_dp_min = matrix[0][:]

#두번째 줄부터
for i in range(1, N):
    curr_dp_max = [0] * 3  #현재줄의 최대값
    curr_dp_min = [0] * 3  #현재줄의 최소값
    .........

이거였는데.. 코드를 제출할때마다 메모리제한때문에 문제가 오답처리되었습니다. DP문제임에도 메모리제한을 빡빡하게 두었더라구요
그래서 코드를 6번정도 수정했는데 처음 수정한건 2차원배열이 아닌 1차원배열을 이용해 매번 현재값을 다음값으로 바꿔주어 현재와 이전값만 저장하게끔 하는 방법으로 했습니다.

# 현재 줄을 이전 줄로 업데이트
prev_dp_max = curr_dp_max[:]
prev_dp_min = curr_dp_min[:]

그래도 메모리가 부족해 아예 matrix를 사용하지 않아보기로 했습니다. 코드의 알고리즘이 변한건 아니지만 매트릭스에 따로 문제에서 주어진 수들을 저장하는게 아닌, 한줄 한줄 읽으며 바로바로 값을 업데이트해 나가는 방식입니다.

파이썬은 유용한 대신 메모리 사용량이 높아질 수 있습니다. 그래서 이것과 같은 최적화가 필요할 경우가 생깁니다. c, c++, java는 어떻게 푸는지, 메모리는 얼마나 더 적게드는지 궁금합니다.