### PR TITLE
8-kangrae-jo

### DIFF
--- a/kangrae-jo/HEAP/8-kangrae-jo.cpp
+++ b/kangrae-jo/HEAP/8-kangrae-jo.cpp
@@ -1,0 +1,38 @@
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int mix(int a, int b){
+    return a + b*2;
+}
+
+int solution(vector<int> scoville, int K) {
+    int answer = 0;
+    
+    // min heap
+    priority_queue<int, vector<int>, greater<int>> pq;
+    for (int i : scoville){
+        pq.push(i);
+    }
+    
+    int foodLast;
+    int foodCurrent;
+    while (!pq.empty()){
+        if (pq.size() == 1) return pq.top() >= K ? answer : -1;
+        
+        foodLast = pq.top();
+        pq.pop();
+        foodCurrent = pq.top();
+        pq.pop();
+        
+        if (foodLast >= K) return answer;
+        
+        pq.push(mix(foodLast, foodCurrent));
+        answer++;
+    }
+    
+    return -1;
+}
+// https://school.programmers.co.kr/learn/courses/30/lessons/42626

--- a/kangrae-jo/README.md
+++ b/kangrae-jo/README.md
@@ -6,5 +6,6 @@
 | 2차시 | 2024.10.01 |  BruteForce  | [카펫](https://school.programmers.co.kr/learn/courses/30/lessons/42842)| [#6]https://github.com/AlgoLeadMe/AlgoLeadMe-12/pull/6|
 | 3차시 | 2024.10.05 |  BFS  | [토마토](https://www.acmicpc.net/problem/7576)| [#10]https://github.com/AlgoLeadMe/AlgoLeadMe-12/pull/10|
 | 4차시 | 2024.10.05 |  BFS  | [아이템 줍기](https://school.programmers.co.kr/learn/courses/30/lessons/87694)|[#12]https://github.com/AlgoLeadMe/AlgoLeadMe-12/pull/12|
+| 8차시 | 2024.11.12 |  HEAP  | [더 맵게](https://school.programmers.co.kr/learn/courses/30/lessons/42626)|[#27]https://github.com/AlgoLeadMe/AlgoLeadMe-12/pull/27|
 
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[더 맵게](https://school.programmers.co.kr/learn/courses/30/lessons/42626)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
46m

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

### 문제 요약

```
섞은 음식의 스코빌 지수 = 가장 맵지 않은 음식의 스코빌 지수 + (두 번째로 맵지 않은 음식의 스코빌 지수 * 2)
```
위 방식대로 스코빌 지수를 섞어서,
모든 음식의 스코빌 지수가 K이상이 되게 할 때, 
섞어야 하는 최소 횟수를 반환하는 문제이다.


### 풀이

처음 생각났던 풀이는 다음과 같다.

```
1. 벡터 정렬
2. 가장 앞의 값이 K이상인지 확인
2-1. 아니라면 '두 번째로 맵지않은 음식자리'에 '섞은 음식의 스코빌 지수'를 넣기
(반복)
```

이 방식에는 문제가 있다. 
섞은 스코빌 지수가 벡터의 정렬된 상태를 유지하지 않는다는 것이었다.

'정렬된 상태를 유지' 라는 생각은 max/min heap이 생각이 들게 했다.

그래도 처음 풀이 그래도 해결해보고 싶어서
매 반복마다 sort를 했었다.

결과는 당연히 시간초과였고 heap을 사용하기로 결정했다.


### 정답 풀이

c++ 에서는 heap을 사용하기 위해서 '우선순위 큐'를 활용할 수 있다.
큐는 FIFO 지만, 우선순위 큐는 말 그대로 우선순위를 정할 수 있다.

수도코드는 다음과 같다.

```
1. 우선순위 큐에 스코빌 지수 삽입
2. 스코빌 지수를 2개씩 뽑기
3. 먼저 뽑은 스코빌 지수가 K보다 크다면 return
4. 아니라면, 2개의 스코빌 지수 섞은뒤 재 삽입
(2 번으로 돌아가서 반복)
```

( min heap은 원소 삽입시에 root에 min값을 두기 때문에 정렬이 필요하지 않다. )

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

우선 순위 큐 선언부분은 까먹어서 검색을 했네요.

```cpp
priority_queue<int, vector<int>, greater<int>> pq;
```
vector<int>는 왜 들어가는지 잘 몰랐는데,
[priority_queue 참고자료](https://www.geeksforgeeks.org/cpp-stl-heap/)
여기를 보니까 살짝알게 되었습니다.

직접적으로 알게된건 없는데, 이미 선언된 vector에 대해서,
vector의 begin()과 end()를 주면 make_heap()함수를 사용할 수 있다는 것을 알게 되었고
따라서 내부적으로 구현되는 콘테이너는 vector이지 않을까 생각을 했습니다.

조금 찾아보니까 이걸 '구현체'라고 하는 걸 알게 되었습니다.

(틀린 것 있으면 지적해 주세요..)

