### PR TITLE
14-g0rnn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 cmake-build-debug/
 CMakeLists.txt
+.clang-tidy

--- a/g0rnn/backtracking/14-g0rnn.cpp
+++ b/g0rnn/backtracking/14-g0rnn.cpp
@@ -17,7 +17,7 @@ int chess[15] = {0};
 bool canMoveTo(int col, int row) {
 	for (int i = 0; i < n; i++) {
 		if (chess[i] == EMPTY) continue;
-		if (abs(col - i) == row - chess[i]) return false; // 대각선인 경우
+		if (abs(col - i) == row - chess[i]) return false; // 대각선인 경우 (row는 항상 chess[i]보다 큼)
 		if (i == col) return false; // 같은 열인 경우
 	}
 	return true;

--- a/g0rnn/backtracking/14-g0rnn.cpp
+++ b/g0rnn/backtracking/14-g0rnn.cpp
@@ -1,0 +1,44 @@
+//
+// Created by 김균호 on 2025. 1. 7..
+//
+#include <iostream>
+using namespace std;
+
+#define EMPTY -1
+
+int n;
+int chess[15] = {0};
+// 배열의 value은 퀸이 놓여진 row를 의미
+// 배열의 index는 퀸이 놓여진 column을 의미
+// ex) chess[3] = 5 -> 퀸이 5행 3열에 놓여져 있다는 의미
+
+// col과 row는 퀸을 놓을 열과 행
+// col과 row로 받은 위치에 대해 이미 놓여진 퀸을 피해 놓을 수 있는지
+bool canMoveTo(int col, int row) {
+	for (int i = 0; i < n; i++) {
+		if (chess[i] == EMPTY) continue;
+		if (abs(col - i) == row - chess[i]) return false; // 대각선인 경우
+		if (i == col) return false; // 같은 열인 경우
+	}
+	return true;
+}
+
+int findQueen(int cnt, int row) {
+	if (cnt == n) return 1;
+
+	int total = 0;
+	for (int col = 0; col < n; col++) {
+		if (!canMoveTo(col, row)) continue;
+		chess[col] = row;
+		total += findQueen(cnt + 1, row + 1); // 가능한 경우의 수의 총합
+		chess[col] = EMPTY;
+	}
+	return total;
+}
+
+int main() {
+	cin >> n;
+	fill(chess, chess + n, EMPTY);
+	cout << findQueen(0, 0);
+	return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[N-Queen](https://www.acmicpc.net/problem/9663)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
50m

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
### 어떻게 접근해야할까
문제에서 핵심이 되는 수도 코드는 꽤나 간단합니다. 이전 [13pr](https://github.com/AlgoLeadMe/AlgoLeadMe-12/pull/52)에서 언급했던 백트레킹 문제들을 풀어보았다면 수도 코드는 간단히 생각할 수 있었을겁니다.

```
0. 둘 수 있는 칸에 대해
1. 퀸을 둔다.
2. total += backtracking()
3. 퀸을 제거한다.
4. print total
```

수도 코드의 구현은 쉬울것 같은데.. 둘 수 있는 칸은 어떻게 정해야할까요? 아마 이미 놓여진 퀸들에게 영향을 받지 않는 위치여야 할겁니다. 이전 퀸들과 같은 행과 열에 위치해서는 안될 것이고 대각선 상에 위치해서도 안됩니다.

행과 열을 구분하는 건 쉬우니 나중에 구현할 때 더 생각해보고.. 대각선은 어떻게 알 수 있을가요? 저는 이전 퀸(prev)의 위치와 지금 놓을 퀸(cur)의 위치의 차이로 계산했습니다. `prev.column - cur.column == prev.row - cur.row`인 경우가 대각선입니다. 

### 아이디어 구상은 끝났으니 이제 구현해봅시다.
```
주어진 row에 대해 가능한 경우의 수를 반환하는 함수

func findQueen (int row) :
    if  n개의 퀸을 두었으면 return 1
    else
        체스 판에서 퀸을 둘 수 있는 칸에 대해
            퀸을 둔다.
            total += findQueen
            퀸을 제거한다.
    return total
```
좀 더 자세한 수도코드는 위와 같습니다.

backtracking하는 함수의 종료 조건은 n개의 퀸을 체스판에 모두 놓은 경우이므로 1을 반환합니다. 이후 total에 이 값들이 쌓여 최종 결과값이 됩니다.

구현할 때 n*n의 체스판으로 해도 될것 같으나 제 생각엔 그렇게 많은 배열은 필요없다고 생각하여 1차원 배열(`chess`)을 사용하였습니다.

2차원 배열로 구현했을 때에 백트레킹은 아마 `위에서 아래로` 내려가면서 퀸을 둘 것입니다. 그렇기에 당연히 같은 행에 위치할 일은 없습니다. 그리고 대각선의 위치를 판별하는 방법은 서로의 위칫값이므로 4가지 값만 있으면 됩니다. 

이제 체스판의 각 위치 정보를 1차원 배열에 담아 풀면 됩니다. 참고로 `chess`의 index는 퀸이 놓여진 column을 의미하고 value는 row를 의미합니다. 

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
