### PR TITLE
30-wnsmir

### DIFF
--- a/wnsmir/그리디/요격시스템.py
+++ b/wnsmir/그리디/요격시스템.py
@@ -1,0 +1,12 @@
+def solution(targets):
+    # 끝나는 지점 기준 오름차순 정렬
+    targets.sort(key=lambda x: x[1])
+
+    count = 0
+    last_shot = -1
+    for start, end in targets:
+        if start >= last_shot:
+            count += 1
+            last_shot = end
+            
+    return count


### PR DESCRIPTION
## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/181188

## ✔️ 소요된 시간
1h

## ✨ 수도 코드
처음에 이문제를보고 잠시 조합을 떠올렸습니다.
각 조합별로 다 시도해보고, 그중 가장 작은 원소의 수를 답으로 return하려했지만 1부터 50만의 조합은 너무도 크더군요,,

바로 접고 전에 오흠스 알고리즘수업떄 비슷한유형을 들은 기억이 나 그리디를 두번쨰로 떠올렸습니다.

구간이 [1, 3] 이렇게 있다면 처음엔 첫번쨰원소를 기준으로 잡으려했는데 가만히 생각해보니 최대중첩을 위해선 앞에서부터 시작한다고 했을댸 해당구간의 가장 뒤를 기준으로 잡아야 최대한 많은구간을 겹칠 수 있었습니다.

즉 구간을 빠트리지 않기 위해 구간의 끝을 기준으로 먼저 정렬을 해주고,
첫구간부터 끝지점을 기준으로 미사일읠 요격해줍니다.

요격할떄 해당구간의 다른미사일도 제거해주고, 남은 구간이 없을떄까지 반복해줍니다.

그리디를 푼지 오래돼서 이걸 그대로 구현해버렸습니다..
```python
def solution(targets):
    count = 0
    # 뒤의 원소로 정렬
    sorted_targets = sorted(targets, key = lambda x:x[1])
    
    # 첫번쨰 구간부터 끝나는지점을 기준으로 미사일 요격
    for target in sorted_targets:
        # 모두 요격하면 종료
        if len(targets) == 0:
            break
        if target not in targets:
            continue
            
        end = target[1]
        n = len(targets)
        selected = []
        
        flag = False
        for i in range(n):
            # 시작은 end보다 작고 끝은 크거나 같은 구간이라면 삭제
            if end > targets[i][0] and targets[i][1] >= end:
                selected.append(i)
                flag = True
        
        for i in reversed(selected):
            del targets[i]
        
        if flag == True:
            count += 1

    return count
```
삭제가 들어가는순간 시간초과가 나더라구요
사실 이문제는 굳이 구현을 해줄 필요가 없었습니다

```python
def solution(targets):
    # 끝나는 지점 기준 오름차순 정렬
    targets.sort(key=lambda x: x[1])

    count = 0
    last_shot = -1
    for start, end in targets:
        if start >= last_shot:
            count += 1
            last_shot = end
            
    return count
```
그냥 미사일 발사지점을 정해두고 다음구간의 시작점이 마지막 발사지점보다 크거나 같으면, 그 구간의 마지막지점을 다시 발사지점으로 업데이트해줍니다. 같거나 큰 이유는, 같을떄도 경계값은 요격이 안되기 때문입니다.