### PR TITLE
32-wnsmir

### DIFF
--- a/wnsmir/해시/순위 검색.py
+++ b/wnsmir/해시/순위 검색.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from itertools import combinations
+from bisect import bisect_left
+
+def solution(info, query):
+    # 전처리: 16개 키에 점수 적재
+    db = defaultdict(list)
+    for s in info:
+        lang, job, career, food, score = s.split()
+        score = int(score)
+        fields = [lang, job, career, food]
+
+        # 4개의 필드에서 0~4개를 '-'로 치환한 모든 조합(2^4=16)
+        for r in range(5):
+            for idxs in combinations(range(4), r):
+                key = fields[:]  # 복사
+                for i in idxs:
+                    key[i] = '-'
+                db[tuple(key)].append(score)
+
+    # 각 키의 점수 리스트 정렬(이분 탐색)
+    for k in db:
+        db[k].sort()
+
+    # 쿼리 처리: 키 만들고, lower_bound로 개수 계산
+    answer = []
+    for que in query:
+        # "java and backend and junior and pizza 100" -> ["java","backend","junior","pizza","100"]
+        que = que.replace(" and ", " ")
+        a, b, c, d, min_score = que.split()
+        key = (a, b, c, d)
+        scores = db.get(key, [])
+        # 점수 >= min_score 인 원소 개수 = 전체 - 첫 위치
+        idx = bisect_left(scores, int(min_score))
+        answer.append(len(scores) - idx)
+
+    return answer


### PR DESCRIPTION
## 🔗 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/72412

## ✔️ 소요된 시간
40min

## ✨ 수도 코드
쿼리와 학생정보를 미리 파싱해두고 각 쿼리를 학생리스트에 대조해보면서 정답리스트에 수를 채워나가는 그냥 구현으로 20분만에 풀었다가...
바로 시간초과나서 GPT와함께 문제를 풀어보았습니다 ㅎ..

```python
def solution(info, query):
    # 학생 정보 파싱
    students = [s.split() for s in info]
    for s in students:
        s[4] = int(s[4])  # 점수를 int로

    # 쿼리 파싱
    querys = []
    for q in query:
        parts = q.split(" and ")
        last_part = parts[-1].split()
        parts[-1] = last_part[0]
        parts.append(int(last_part[1]))
        querys.append(parts)

    # 쿼리 개수만큼 결과 배열
    result = [0] * len(querys)

    # 각 쿼리별로 학생 대조
    for qi, que in enumerate(querys):
        cnt = 0
        for student in students:
            Flag = True

            # 언어
            if not (que[0] == student[0] or que[0] == '-'):
                Flag = False
            # 직군
            if not (que[1] == student[1] or que[1] == '-'):
                Flag = False
            # 경력
            if not (que[2] == student[2] or que[2] == '-'):
                Flag = False
            # 소울푸드
            if not (que[3] == student[3] or que[3] == '-'):
                Flag = False
            # 점수 (학생 점수 >= 쿼리 최소 점수)
            if not (student[4] >= que[4]):
                Flag = False

            if Flag:
                cnt += 1

        result[qi] = cnt

    return result
```

이렇게 풀게되면 일종의 브루트포스방식으로 시간복잡도가 N*Q가 됩니다.
따라서 지피티5는 전처리 + 이분탐색을 활용하라고 가르쳐주었습니다..

• 4개 필드 각각이 **값 또는 -**일 뿐 → 총 2⁴=16 가지 키 조합
• 각 지원자에 대해 16개의 모든 키를 만들어 해당 키의 점수 리스트에 푸시
• 쿼리는 4필드의 정확한 키(와 -)로 해당 리스트만 조회 → 이분 탐색으로 “최소 점수 이상”의 개수를 O(log L)에 계산

16가지의 키는 각 속성의 값들이 아니라 -인지 값인지 의 경우의 수입니다.
이부분에 처음에 햇갈렸는데 각 쿼리는 와일드카드 아니면 어떤 값이 주어지고, 와일드카드라면 해당조건을 무시해도 됩니다.

즉 info: python backend junior pizza 150에서 생기는 키들은
	•("python","backend","junior","pizza")  ← 정확 일치용
	•("python","backend","junior","-")
	•("python","-","junior","pizza")
	•("-","backend","junior","pizza")
	•("-","-","-","-")
… (총 16개) 가 됩니다.

따라서 전처리 O(N log N) + 쿼리당 O(log L) 는 효율성검사도 통과합니다!

```python
from collections import defaultdict
from itertools import combinations
from bisect import bisect_left

def solution(info, query):
    # 전처리: 16개 키에 점수 적재
    db = defaultdict(list)
    for s in info:
        lang, job, career, food, score = s.split()
        score = int(score)
        fields = [lang, job, career, food]

        # 4개의 필드에서 0~4개를 '-'로 치환한 모든 조합(2^4=16)
        for r in range(5):
            for idxs in combinations(range(4), r):
                key = fields[:]  # 복사
                for i in idxs:
                    key[i] = '-'
                db[tuple(key)].append(score)

    # 각 키의 점수 리스트 정렬(이분 탐색)
    for k in db:
        db[k].sort()

    # 쿼리 처리: 키 만들고, lower_bound로 개수 계산
    answer = []
    for que in query:
        # "java and backend and junior and pizza 100" -> ["java","backend","junior","pizza","100"]
        que = que.replace(" and ", " ")
        a, b, c, d, min_score = que.split()
        key = (a, b, c, d)
        scores = db.get(key, [])
        # 점수 >= min_score 인 원소 개수 = 전체 - 첫 위치
        idx = bisect_left(scores, int(min_score))
        answer.append(len(scores) - idx)

    return answer
```