### PR TITLE
34-wnsmir

### DIFF
--- a/wnsmir/구현/드래곤커브.py
+++ b/wnsmir/구현/드래곤커브.py
@@ -1,0 +1,50 @@
+N = int(input())
+grid = [[0]*101 for _ in range(101)]
+
+def rot90(p, pivot):
+    x, y = p
+    px, py = pivot
+    return (px - (y - py), py + (x - px))
+
+def curve(last_gen, last_spot):
+    new_gen = last_gen[:]
+    for dot in reversed(last_gen[:-1]): # 중심 제외 역순으로
+        nx, ny = rot90(dot, last_spot)
+        if 0 <= nx <= 100 and 0 <= ny <= 100:
+            grid[ny][nx] = 1
+        new_gen.append((nx, ny))
+    return new_gen, new_gen[-1]
+
+for _ in range(N):
+    x, y, d, g = map(int, input().split())
+
+    last_gen = [(x, y)]
+    grid[y][x] = 1
+
+    # 0세대 만들기
+    if d == 0:
+        last_spot = (x+1, y)
+    elif d == 1:
+        last_spot = (x, y-1)
+    elif d == 2:
+        last_spot = (x-1, y)
+    else:
+        last_spot = (x, y+1)
+
+    last_gen.append(last_spot)
+    lx, ly = last_spot
+    if 0 <= lx <= 100 and 0 <= ly <= 100:
+        grid[ly][lx] = 1
+
+    # g 세대수만큼
+    for _ in range(g):
+        last_gen, last_spot = curve(last_gen, last_spot)
+
+# 사각형 개수
+answer = 0
+for y in range(100):
+    for x in range(100):
+        if grid[y][x] == 1 and grid[y][x+1] == 1 and grid[y+1][x] == 1 and grid[y+1][x+1] == 1:
+            answer += 1
+
+print(answer)


### PR DESCRIPTION
## 🔗 문제 링크
https://www.acmicpc.net/problem/15685

## ✔️ 소요된 시간
1h

## ✨ 수도 코드
상어를 잡기전 몸풀기문제로 한번 풀어보았습니다.
이 문제에서 생각했던점은 딱 두가지였습니다.

중심점이 있는 상태에서의 회전, 마지막 좌표 즉 다음 중심점을 어떻게 업데이트해주어야 할 것인가?

중심점이 있는 회전은
```python
def rot90(p, pivot):
    x, y = p
    px, py = pivot
    return (px - (y - py), py + (x - px))
```
이렇게 처리해주었습니다.

다음 중심점을 처리하는게 좀 시간이 많이 걸렸는데 처음에는 시작점에서 bfs로 가장멀리있는 점을 찾아서 매번 업데이트시켜줄까 했지만 너무 투머치인것 같아 좀더 생각해본 결과

회전해서 새 리스트에 추가해줄때 중심점으로 부터 가까운점들부터 추가해주면 마지막에 추가되는점이 마지막점이 되는 점을 이용했습니다.
즉 중심점으로부터 가까운점을 먼저 추가해주려면 이전세대의 점들을 뒤에서부터 순회하며 세 세대 뒤에 하나씩 추가해줍니다.

그럼 제일 마지막원소가 늘 다음 회전의 중심점이 됩니다.

이후 구현은 쉽게 하실 수 있을겁니다!
I, j를 순회하며 오른쪽, 아래, 오른쪽아래 3점이 모두 1이면 answer += 1 하도록 간단하게 구현했습니다.
(늘 우하향하기 뗴문에 중복없음)

아 참고로 x y의 방향이 일반적이 문제와는 반대여서 신경써주어야 합니다.

```python
N = int(input())
grid = [[0]*101 for _ in range(101)]

def rot90(p, pivot):
    x, y = p
    px, py = pivot
    return (px - (y - py), py + (x - px))

def curve(last_gen, last_spot):
    new_gen = last_gen[:]
    for dot in reversed(last_gen[:-1]): # 중심 제외 역순으로
        nx, ny = rot90(dot, last_spot)
        if 0 <= nx <= 100 and 0 <= ny <= 100:
            grid[ny][nx] = 1
        new_gen.append((nx, ny))
    return new_gen, new_gen[-1]

for _ in range(N):
    x, y, d, g = map(int, input().split())

    last_gen = [(x, y)]
    grid[y][x] = 1

    # 0세대 만들기
    if d == 0:
        last_spot = (x+1, y)
    elif d == 1:
        last_spot = (x, y-1)
    elif d == 2:
        last_spot = (x-1, y)
    else:
        last_spot = (x, y+1)

    last_gen.append(last_spot)
    lx, ly = last_spot
    if 0 <= lx <= 100 and 0 <= ly <= 100:
        grid[ly][lx] = 1

    # g 세대수만큼
    for _ in range(g):
        last_gen, last_spot = curve(last_gen, last_spot)

# 사각형 개수
answer = 0
for y in range(100):
    for x in range(100):
        if grid[y][x] == 1 and grid[y][x+1] == 1 and grid[y+1][x] == 1 and grid[y+1][x+1] == 1:
            answer += 1

print(answer)
```